### PR TITLE
Fix the same date not allowed to be selected when using TimePicker.

### DIFF
--- a/BlazorDateRangePicker/DateRangePicker.razor.cs
+++ b/BlazorDateRangePicker/DateRangePicker.razor.cs
@@ -739,7 +739,7 @@ namespace BlazorDateRangePicker
         public virtual async Task ClickDate(DateTimeOffset date)
         {
             HoverDate = null;
-            if (TEndDate.HasValue || TStartDate == null || date < TStartDate)
+            if (TEndDate.HasValue || TStartDate == null || date.Date.Add(EndTime) < TStartDate)
             {
                 // picking start
                 TEndDate = null;


### PR DESCRIPTION
I tried achieving selection of selecting a period of a few hours of the same date, using TimePicker. This is not allowed (the second click does not finish the selection).

To reproduce:
- Have a DateRangePicker with TimePicker=true.
- Choose a time for the start time of > 0:00, for example 5:00.
- Choose a time for the end time, for example 8:00.
- Now try to change the date range to the same date, by clicking on the same date twice.
-> The second click is not finishing the selection.