### PR TITLE
Allow ChosenLabel to be accessed (for example with creating a custom PickerTemplate)

### DIFF
--- a/BlazorDateRangePicker/DateRangePicker.razor.cs
+++ b/BlazorDateRangePicker/DateRangePicker.razor.cs
@@ -412,7 +412,7 @@ namespace BlazorDateRangePicker
         public CalendarType LeftCalendar { get; set; }
         public CalendarType RightCalendar { get; set; }
 
-        internal string ChosenLabel { get; set; }
+        public string ChosenLabel { get; private set; }
         internal bool CalendarsVisible { get; set; }
         internal bool Loading { get; set; }
         public DateTimeOffset? HoverDate { get; set; }


### PR DESCRIPTION
I would like to use the ChosenLabel property in a custom PickerTemplate, but I cannot because of it being internal. I made it public, and to prevent outside writes, made the setter private (which turns out could be done without breaking the library code).