### PR TITLE
Fix custom date ranges with time not working (like 'last 30 minutes' or 'last 24h')

### DIFF
--- a/BlazorDateRangePicker/DateRangePicker.razor.cs
+++ b/BlazorDateRangePicker/DateRangePicker.razor.cs
@@ -664,6 +664,13 @@ namespace BlazorDateRangePicker
             else
             {
                 var dates = Ranges[label];
+
+                if (TimePicker == true)
+                {
+                    StartTime = dates.Start.TimeOfDay;
+                    EndTime = dates.End.TimeOfDay;
+                }
+
                 TStartDate = SafeSetStartTime(dates.Start);
                 TEndDate = SafeSetEndTime(dates.End.Date);
 


### PR DESCRIPTION
The click handler of clicking a custom range simply ignored the time part of a custom range, and kept the already selected start/end times.