### PR TITLE
Fix awaiting change handlers before closing

### DIFF
--- a/BlazorDateRangePicker/BlazorDateRangePicker.csproj
+++ b/BlazorDateRangePicker/BlazorDateRangePicker.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
+<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2;net5;net6;net7;net8</TargetFrameworks>
@@ -9,7 +9,7 @@
     <LangVersion>preview</LangVersion>
     <RazorLangVersion>3.0</RazorLangVersion>
 
-    <Version>4.5.0</Version>
+    <Version>4.5.1</Version>
     <Authors>Sergey Zaikin</Authors>
     <PackageId>BlazorDateRangePicker</PackageId>
     <Title>Blazor Date Range Picker</Title>

--- a/BlazorDateRangePicker/DateRangePicker.razor.cs
+++ b/BlazorDateRangePicker/DateRangePicker.razor.cs
@@ -1,4 +1,4 @@
-﻿/**
+/**
 * @author: Sergey Zaikin zaikinsr@yandex.ru
 * @copyright: Copyright (c) 2019 Sergey Zaikin. All rights reserved.
 * @license: Licensed under the MIT license. See http://www.opensource.org/licenses/mit-license.php
@@ -842,6 +842,8 @@ namespace BlazorDateRangePicker
 
         public async Task ClickApply(MouseEventArgs e)
         {
+            await Close();
+            
             StartDate = TStartDate;
             await StartDateChanged.InvokeAsync(TStartDate);
 
@@ -856,8 +858,6 @@ namespace BlazorDateRangePicker
                     End = TEndDate.Value
                 });
             }
-
-            await Close();
         }
 
         public async Task ClickCancel(MouseEventArgs e)


### PR DESCRIPTION
This has proven to be an issue for us when we need to do long-running tasks when reacting to change events (specifically, we make an HTTP request when the range changes). Consider the following:

Razor:
```razor
<DateRangePicker OnRangeSelect=RangeChanged />
```

C#:
```csharp
private async Task RangeChanged(DateRange range)
{
    _Range = range;
    await Save();
}

private async Task Save()
{
   // simulated work
    await Task.Delay(1000);
}
```

In this example, the selector will only close after 1000ms, whereas it makes more sense UX-wise to close immediately