### PR TITLE
fix: TimePicker24Hour not being used on left calendar

### DIFF
--- a/BlazorDateRangePicker/DateRangePicker.razor
+++ b/BlazorDateRangePicker/DateRangePicker.razor
@@ -46,7 +46,7 @@ else if (PickerTemplate != null)
                 @if (TimePicker == true)
                 {
                     <div class="calendar-time">
-                        <TimePicker Side="@SideType.Left" Day="TStartDate"
+                        <TimePicker Side="@SideType.Left" Day="TStartDate" TimePicker24Hour="TimePicker24Hour"
                                     Time="StartTime" TimeChanged="t => TimeChanged(start: t)" />
                     </div>
                 }


### PR DESCRIPTION
If TimePicker24Hour parameter is set to False while displaying both a left and right side calendar, the left calendar hour input will still display the 24 hours.

Before change:
![Captura de ecrã 2024-07-24 130840](https://github.com/user-attachments/assets/7309f793-b327-4864-ad6d-321dc3caa92e)

After change:
![AfterChange](https://github.com/user-attachments/assets/148a8355-46e8-4f89-b2d0-3d3c0774f070)


this will fix issue #104 